### PR TITLE
Use different selector for disp.cc mobile version

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var elements = document.querySelectorAll('.record');
+var selector = document.location.pathname.startsWith('/m/') ? '.fgG0' : '.record';
+var elements = document.querySelectorAll(selector);
 if (elements.length) {
   var line = Array.prototype.filter.call(elements,function(record) {
     return record.textContent.indexOf('文章網址') !== -1;


### PR DESCRIPTION
There are lots of Disp.cc links shared from mobile devices, and its DOM structure is different from the desktop version. We need to use a different DOM selector.
